### PR TITLE
Target Keyを明示的に扱う Trainerを実装

### DIFF
--- a/src/exp/agents/curiosity/hierarchical.py
+++ b/src/exp/agents/curiosity/hierarchical.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import override
 
 import torch
-import torch.nn.functional as F
 from pamiq_core import Agent
 from pamiq_core.utils.schedulers import StepIntervalScheduler
 from torch import Tensor

--- a/src/exp/agents/curiosity/hierarchical.py
+++ b/src/exp/agents/curiosity/hierarchical.py
@@ -1,0 +1,317 @@
+from pathlib import Path
+from typing import override
+
+import torch
+import torch.nn.functional as F
+from pamiq_core import Agent
+from pamiq_core.utils.schedulers import StepIntervalScheduler
+from torch import Tensor
+from torch.distributions import Distribution
+
+from exp.aim_utils import get_global_run
+from exp.data import BufferName, DataKey
+from exp.models import ModelName
+
+
+class HierarchicalCuriosityAgent(Agent[Tensor, Tensor]):
+    """A reinforcement learning agent that uses hierarchical curiosity-driven
+    exploration.
+
+    This agent implements hierarchical curiosity-driven exploration by
+    maintaining multiple forward dynamics models at different
+    hierarchical levels. Each level predicts observations at different
+    abstraction levels, and prediction errors are combined with learned
+    coefficients to generate intrinsic rewards. The agent uses a policy-
+    value network for action selection.
+    """
+
+    def __init__(
+        self,
+        num_hierarchical_levels: int = 2,
+        surprisal_coefficient_vector_seed: int = 8391,
+        log_every_n_steps: int = 1,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        """Initialize the HierarchicalCuriosityAgent.
+
+        Args:
+            num_hierarchical_levels: Number of hierarchical levels for forward dynamics models.
+                Must be >= 1.
+            surprisal_coefficient_vector_seed: Random seed for generating coefficient vectors
+                that weight prediction errors at each hierarchical level.
+            log_every_n_steps: Frequency of logging metrics to Aim.
+            device: Device to run computations on.
+            dtype: Data type for tensors.
+        Raises:
+            ValueError: If num_hierarchical_levels is less than 1.
+        """
+        super().__init__()
+
+        if num_hierarchical_levels < 1:
+            raise ValueError(
+                f"`num_hierarchical_levels` must be >= 1! Your input: {num_hierarchical_levels}"
+            )
+
+        self.num_hierarchical_levels = num_hierarchical_levels
+        self.surprisal_coefficient_vector_seed = surprisal_coefficient_vector_seed
+        self.surprisal_coefficient_vectors: list[Tensor | None] = [
+            None
+        ] * num_hierarchical_levels
+
+        self.metrics: dict[str, float] = {}
+        self.scheduler = StepIntervalScheduler(log_every_n_steps, self.log_metrics)
+        self.global_step = 0
+
+        self.device = device
+        self.dtype = dtype
+
+        # Initialize hidden states (will be properly set in setup())
+        self.policy_hidden_state: Tensor | None = None
+        self.forward_dynamics_hiddens: list[Tensor | None] = []
+
+    @override
+    def on_inference_models_attached(self) -> None:
+        """Retrieve models when models are attached.
+
+        Initializes forward dynamics models for each hierarchical level
+        and the policy-value network.
+        """
+        super().on_inference_models_attached()
+
+        self.forward_dynamicses = [
+            self.get_inference_model(ModelName.FORWARD_DYNAMICS + str(i))
+            for i in range(self.num_hierarchical_levels)
+        ]
+
+        self.policy_value = self.get_inference_model(ModelName.POLICY_VALUE)
+
+    @override
+    def on_data_collectors_attached(self) -> None:
+        """Retrieve data collectors when collectors are attached.
+
+        Initializes data collectors for policy and forward dynamics at
+        each hierarchical level.
+        """
+        super().on_data_collectors_attached()
+
+        self.collector_policy = self.get_data_collector(BufferName.POLICY)
+        self.collectors_fd = [
+            self.get_data_collector(BufferName.FORWARD_DYNAMICS + str(i))
+            for i in range(self.num_hierarchical_levels)
+        ]
+
+    @override
+    def setup(self) -> None:
+        """Initialize agent state.
+
+        Resets hidden states for policy and all forward dynamics models,
+        clears predicted observations, and initializes step data
+        collectors.
+        """
+        super().setup()
+        self.policy_hidden_state = None
+        self.forward_dynamics_hiddens: list[Tensor | None] = [
+            None
+        ] * self.num_hierarchical_levels
+
+        self.predicted_obses: list[Tensor] | None = None
+
+        self.step_data_policy: dict[str, Tensor] = {}
+        self.step_data_fd = [
+            dict[str, Tensor]() for _ in range(self.num_hierarchical_levels)
+        ]
+
+    @override
+    def step(self, observation: Tensor) -> Tensor:
+        """Process observation and return action for environment interaction.
+
+        Computes intrinsic rewards from hierarchical prediction errors,
+        selects actions using the policy network, and updates forward
+        dynamics predictions at all levels.
+
+        Args:
+            observation: Current observation from the environment.
+
+        Returns:
+            Selected action to be executed in the environment.
+        """
+        observation = observation.to(self.device, self.dtype)
+
+        if self.predicted_obses is not None:
+            target_obs = observation
+            reward_sum = torch.tensor(0.0)
+            for i, (pred_obs, coef_vec) in enumerate(
+                zip(
+                    self.predicted_obses,
+                    self.surprisal_coefficient_vectors,
+                    strict=True,
+                )
+            ):
+                # Store target observation
+                self.step_data_fd[i][DataKey.TARGET] = target_obs
+
+                # Collect forward dynamics step data.
+                if DataKey.HIDDEN in (step_data_fd := self.step_data_fd[i]):
+                    self.collectors_fd[i].collect(step_data_fd.copy())
+
+                delta_obs = target_obs = target_obs - pred_obs
+                if coef_vec is None:
+                    g = torch.Generator()
+                    g.manual_seed(self.surprisal_coefficient_vector_seed + i)
+                    coef_vec = torch.where(
+                        torch.rand(
+                            delta_obs.shape,
+                            dtype=delta_obs.dtype,
+                            device=delta_obs.device,
+                            generator=g,
+                        )
+                        < i / (self.num_hierarchical_levels - 1),
+                        1,
+                        -1,
+                    )
+                    self.surprisal_coefficient_vectors[i] = coef_vec
+
+                reward = (delta_obs.square() * coef_vec).mean().cpu()
+                self.metrics[f"reward_{i}"] = reward.item()
+                reward_sum += reward
+            self.metrics["reward_sum"] = reward_sum.item()
+            self.step_data_policy[DataKey.REWARD] = reward_sum
+            if DataKey.HIDDEN in self.step_data_policy:
+                self.collector_policy.collect(self.step_data_policy.copy())
+
+        # ==============================================================================
+        #                               Policy Process
+        # ==============================================================================
+
+        if self.policy_hidden_state is not None:
+            self.step_data_policy[DataKey.HIDDEN] = (
+                self.policy_hidden_state.cpu()
+            )  # Store before update
+
+        action_dist: Distribution
+        value: Tensor
+        action_dist, value, self.policy_hidden_state = self.policy_value(
+            observation, self.policy_hidden_state
+        )
+        action = action_dist.sample()
+        action_log_prob = action_dist.log_prob(action)
+
+        # Data Collection
+        self.step_data_policy[DataKey.OBSERVATION] = observation.cpu()
+        self.step_data_policy[DataKey.ACTION] = action.cpu()
+        self.step_data_policy[DataKey.ACTION_LOG_PROB] = action_log_prob.cpu()
+        self.step_data_policy[DataKey.VALUE] = value.cpu()
+
+        # ==============================================================================
+        #                           Forward Dynamics Process
+        # ==============================================================================
+        self.predicted_obses = []
+        for i, fd in enumerate(self.forward_dynamicses):
+            hidden = self.forward_dynamics_hiddens[i]
+            if hidden is not None:
+                self.step_data_fd[i][DataKey.HIDDEN] = hidden.cpu()
+            self.step_data_fd[i].update(
+                {
+                    DataKey.OBSERVATION: observation.cpu(),
+                    DataKey.ACTION: action.cpu(),
+                }
+            )
+            pred_obs, hidden = fd(observation, action, hidden)
+            self.forward_dynamics_hiddens[i] = hidden
+            self.predicted_obses.append(pred_obs)
+
+        self.scheduler.update()
+        self.global_step += 1
+        return action
+
+    def log_metrics(self) -> None:
+        """Log collected metrics to Aim.
+
+        Writes all metrics in the metrics dictionary to Aim with the
+        current global step.
+        """
+        if run := get_global_run():
+            for k, v in self.metrics.items():
+                run.track(
+                    v,
+                    name=f"curiosity-agent/{k}",
+                    step=self.global_step,
+                    context={"curiosity_type": "hierarchical"},
+                )
+
+    # ------ State Persistence ------
+
+    @override
+    def save_state(self, path: Path) -> None:
+        """Save agent state to disk.
+
+        Saves policy hidden state, forward dynamics hidden states for all levels,
+        surprisal coefficient vectors, and global step counter.
+        Hidden states and coefficient vectors can be None.
+
+        Args:
+            path: Directory path where to save the state.
+        """
+        super().save_state(path)
+        path.mkdir(exist_ok=True)
+
+        # Save policy hidden state
+        if self.policy_hidden_state is not None:
+            torch.save(self.policy_hidden_state, path / "policy_hidden_state.pt")
+
+        # Save forward dynamics hidden states
+        for i, hidden in enumerate(self.forward_dynamics_hiddens):
+            if hidden is not None:
+                torch.save(hidden, path / f"forward_dynamics_hidden_{i}.pt")
+
+        # Save surprisal coefficient vectors
+        for i, coef_vec in enumerate(self.surprisal_coefficient_vectors):
+            if coef_vec is not None:
+                torch.save(coef_vec, path / f"surprisal_coefficient_vector_{i}.pt")
+
+        # Save global step
+        (path / "global_step").write_text(str(self.global_step), "utf-8")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        """Load agent state from disk.
+
+        Restores policy hidden state, forward dynamics hidden states for all levels,
+        surprisal coefficient vectors, and global step counter.
+        Hidden states and coefficient vectors are set to None if the corresponding files don't exist.
+
+        Args:
+            path: Directory path from where to load the state.
+        """
+        super().load_state(path)
+
+        # Load policy hidden state
+        policy_hidden_path = path / "policy_hidden_state.pt"
+        if policy_hidden_path.exists():
+            self.policy_hidden_state = torch.load(
+                policy_hidden_path, map_location=self.device
+            )
+
+        # Load forward dynamics hidden states
+        self.forward_dynamics_hiddens = []
+        for i in range(self.num_hierarchical_levels):
+            fd_hidden_path = path / f"forward_dynamics_hidden_{i}.pt"
+            if fd_hidden_path.exists():
+                hidden = torch.load(fd_hidden_path, map_location=self.device)
+                self.forward_dynamics_hiddens.append(hidden)
+            else:
+                self.forward_dynamics_hiddens.append(None)
+
+        # Load surprisal coefficient vectors
+        self.surprisal_coefficient_vectors = []
+        for i in range(self.num_hierarchical_levels):
+            coef_vec_path = path / f"surprisal_coefficient_vector_{i}.pt"
+            if coef_vec_path.exists():
+                coef_vec = torch.load(coef_vec_path, map_location=self.device)
+                self.surprisal_coefficient_vectors.append(coef_vec)
+            else:
+                self.surprisal_coefficient_vectors.append(None)
+
+        # Load global step
+        self.global_step = int((path / "global_step").read_text("utf-8"))

--- a/src/exp/agents/curiosity/hierarchical.py
+++ b/src/exp/agents/curiosity/hierarchical.py
@@ -68,7 +68,9 @@ class HierarchicalCuriosityAgent(Agent[Tensor, Tensor]):
 
         # Initialize hidden states (will be properly set in setup())
         self.policy_hidden_state: Tensor | None = None
-        self.forward_dynamics_hiddens: list[Tensor | None] = []
+        self.forward_dynamics_hiddens: list[Tensor | None] = [
+            None
+        ] * self.num_hierarchical_levels
 
     @override
     def on_inference_models_attached(self) -> None:
@@ -110,11 +112,6 @@ class HierarchicalCuriosityAgent(Agent[Tensor, Tensor]):
         collectors.
         """
         super().setup()
-        self.policy_hidden_state = None
-        self.forward_dynamics_hiddens: list[Tensor | None] = [
-            None
-        ] * self.num_hierarchical_levels
-
         self.predicted_obses: list[Tensor] | None = None
 
         self.step_data_policy: dict[str, Tensor] = {}

--- a/src/exp/data/__init__.py
+++ b/src/exp/data/__init__.py
@@ -18,3 +18,4 @@ class DataKey(StrEnum):
     ACTION_LOG_PROB = auto()
     REWARD = auto()
     VALUE = auto()
+    TARGET = auto()

--- a/src/exp/trainers/forward_dynamics.py
+++ b/src/exp/trainers/forward_dynamics.py
@@ -278,10 +278,10 @@ class StackedHiddenFDTrainerExplicitTarget(TorchTrainer):
         max_samples: int = 1,
         batch_size: int = 1,
         max_epochs: int = 1,
+        model_name: str = ModelName.FORWARD_DYNAMICS,
         data_user_name: str = BufferName.FORWARD_DYNAMICS,
         min_buffer_size: int | None = None,
         min_new_data_count: int = 0,
-        model_index: int | None = None,
     ) -> None:
         """Initialize the StackedHiddenFDTrainerExplicitTarget.
 
@@ -303,11 +303,6 @@ class StackedHiddenFDTrainerExplicitTarget(TorchTrainer):
         if min_buffer_size < seq_len:
             raise ValueError("Buffer size must be greater than sequence length.")
 
-        model_name = ModelName.FORWARD_DYNAMICS
-        if model_index is not None:
-            data_user_name += str(model_index)
-            model_name += str(model_index)
-
         super().__init__(data_user_name, min_buffer_size, min_new_data_count)
 
         self.partial_optimizer = partial_optimizer
@@ -320,7 +315,6 @@ class StackedHiddenFDTrainerExplicitTarget(TorchTrainer):
         self.max_epochs = max_epochs
         self.data_user_name = data_user_name
         self.model_name = model_name
-        self.model_index = model_index
 
         self.global_step = 0
 
@@ -428,8 +422,6 @@ class StackedHiddenFDTrainerExplicitTarget(TorchTrainer):
 
                 if run := get_global_run():
                     prefix = "forward-dynamics"
-                    if self.model_index is not None:
-                        prefix += str(self.model_index)
                     for k, v in metrics.items():
                         run.track(v, name=f"{prefix}/{k}", step=self.global_step)
                 self.optimizers[OPTIMIZER_NAME].step()

--- a/tests/exp/agents/curiosity/test_hierarchical.py
+++ b/tests/exp/agents/curiosity/test_hierarchical.py
@@ -1,0 +1,225 @@
+import pytest
+import torch
+from pamiq_core.testing import (
+    connect_components,
+    create_mock_buffer,
+    create_mock_models,
+)
+from pytest_mock import MockerFixture
+from torch.distributions import Normal
+
+from exp.agents.curiosity.hierarchical import HierarchicalCuriosityAgent
+from exp.data import BufferName, DataKey
+from exp.models import ModelName
+
+# Constants
+OBSERVATION_DIM = 16
+ACTION_DIM = 4
+HIDDEN_DIM = 32
+DEPTH = 2
+NUM_LEVELS = 3
+
+
+class TestHierarchicalCuriosityAgent:
+    """Tests for the HierarchicalCuriosityAgent class."""
+
+    @pytest.fixture
+    def models(self):
+        # Create forward dynamics models for each hierarchical level
+        models = {}
+        for i in range(NUM_LEVELS):
+            fd_model, _ = create_mock_models()
+            pred_obs = torch.randn(OBSERVATION_DIM)
+            hidden = torch.randn(DEPTH, HIDDEN_DIM)
+            fd_model.inference_model.return_value = (pred_obs, hidden)
+            models[ModelName.FORWARD_DYNAMICS + str(i)] = fd_model
+
+        # Create policy value model
+        policy_value_model, _ = create_mock_models()
+        action_dist = Normal(torch.zeros(ACTION_DIM), torch.ones(ACTION_DIM))
+        value = torch.tensor(0.5)
+        policy_hidden = torch.randn(DEPTH, HIDDEN_DIM)
+        policy_value_model.inference_model.return_value = (
+            action_dist,
+            value,
+            policy_hidden,
+        )
+        models[ModelName.POLICY_VALUE] = policy_value_model
+
+        return models
+
+    @pytest.fixture
+    def buffers(self):
+        buffers = {str(BufferName.POLICY): create_mock_buffer()}
+        for i in range(NUM_LEVELS):
+            buffers[BufferName.FORWARD_DYNAMICS + str(i)] = create_mock_buffer()
+        return buffers
+
+    @pytest.fixture
+    def mock_aim_run(self, mocker: MockerFixture):
+        return mocker.patch("exp.agents.curiosity.hierarchical.get_global_run")
+
+    @pytest.fixture
+    def agent(self, models, buffers, mock_aim_run):
+        agent = HierarchicalCuriosityAgent(
+            num_hierarchical_levels=NUM_LEVELS,
+            surprisal_coefficient_vector_seed=42,
+            log_every_n_steps=5,
+        )
+        connect_components(agent, buffers=buffers, models=models)
+        return agent
+
+    def test_invalid_num_hierarchical_levels(self):
+        """Test that agent raises error for invalid num_hierarchical_levels."""
+        with pytest.raises(ValueError, match="`num_hierarchical_levels` must be >= 1"):
+            HierarchicalCuriosityAgent(num_hierarchical_levels=0)
+
+        with pytest.raises(ValueError, match="`num_hierarchical_levels` must be >= 1"):
+            HierarchicalCuriosityAgent(num_hierarchical_levels=-1)
+
+    def test_setup_step_teardown(
+        self, agent: HierarchicalCuriosityAgent, mocker: MockerFixture
+    ):
+        """Test the main interaction loop of the agent."""
+        agent.setup()
+
+        # Verify initial state
+        assert agent.policy_hidden_state is None
+        assert len(agent.forward_dynamics_hiddens) == NUM_LEVELS
+        assert all(h is None for h in agent.forward_dynamics_hiddens)
+        assert agent.predicted_obses is None
+        assert isinstance(agent.step_data_policy, dict)
+        assert len(agent.step_data_fd) == NUM_LEVELS
+
+        observation = torch.randn(OBSERVATION_DIM)
+
+        # Create spies for data collectors
+        spy_policy_collect = mocker.spy(agent.collector_policy, "collect")
+        spy_fd_collects = []
+        for i in range(NUM_LEVELS):
+            spy = mocker.spy(agent.collectors_fd[i], "collect")
+            spy_fd_collects.append(spy)
+
+        # First step - no reward calculation since no previous predictions
+        action = agent.step(observation)
+        assert action.shape == (ACTION_DIM,)
+        assert agent.global_step == 1
+        assert agent.predicted_obses is not None
+        assert len(agent.predicted_obses) == NUM_LEVELS
+
+        # Data should not be collected on first step (no previous hidden states)
+        assert spy_policy_collect.call_count == 0
+        for spy in spy_fd_collects:
+            assert spy.call_count == 0
+
+        # Second step - should calculate hierarchical rewards
+        observation2 = torch.randn(OBSERVATION_DIM)
+        agent.step(observation2)
+        assert agent.global_step == 2
+
+        # Data collection happens on the NEXT step after hidden states are available
+        # So no collection yet
+        assert spy_policy_collect.call_count == 0
+        for spy in spy_fd_collects:
+            assert spy.call_count == 0
+
+        # Third step - now data should be collected from previous step
+        observation3 = torch.randn(OBSERVATION_DIM)
+        agent.step(observation3)
+        assert agent.global_step == 3
+
+        # Should have collected data for forward dynamics
+        for i, spy in enumerate(spy_fd_collects):
+            assert spy.call_count == 1
+            fd_data = spy.call_args[0][0]
+            assert DataKey.OBSERVATION in fd_data
+            assert DataKey.ACTION in fd_data
+            assert DataKey.HIDDEN in fd_data
+            assert DataKey.TARGET in fd_data
+
+        # Policy data should be collected
+        assert spy_policy_collect.call_count == 1
+        policy_data = spy_policy_collect.call_args[0][0]
+        assert DataKey.OBSERVATION in policy_data
+        assert DataKey.ACTION in policy_data
+        assert DataKey.ACTION_LOG_PROB in policy_data
+        assert DataKey.VALUE in policy_data
+        assert DataKey.REWARD in policy_data
+        assert DataKey.HIDDEN in policy_data
+
+        # Check that coefficient vectors were generated
+        assert all(vec is not None for vec in agent.surprisal_coefficient_vectors)
+
+    def test_logging(self, agent: HierarchicalCuriosityAgent, mock_aim_run):
+        """Test metrics logging at specified intervals."""
+        mock_run = mock_aim_run.return_value
+
+        agent.setup()
+        observation = torch.randn(OBSERVATION_DIM)
+
+        # Step multiple times to trigger logging
+        for _ in range(6):
+            agent.step(observation)
+
+        # Should log on step 5 (log_every_n_steps=5)
+        mock_run.track.assert_called()
+
+        # Extract tracked metrics
+        track_calls = mock_run.track.call_args_list
+        tracked_metrics = {call[1]["name"] for call in track_calls}
+
+        # Verify hierarchical rewards are tracked
+        for i in range(NUM_LEVELS):
+            assert f"curiosity-agent/reward_{i}" in tracked_metrics
+        assert "curiosity-agent/reward_sum" in tracked_metrics
+
+        # Verify context includes curiosity type
+        for call in track_calls:
+            assert call[1]["context"]["curiosity_type"] == "hierarchical"
+
+    def test_save_and_load_state(self, agent: HierarchicalCuriosityAgent, tmp_path):
+        """Test state saving and loading functionality."""
+        agent.setup()
+
+        # Generate coefficient vectors by stepping
+        observation = torch.randn(OBSERVATION_DIM)
+        agent.step(observation)
+        agent.step(observation)  # Ensure coefficient vectors are created
+
+        # Set up some state after stepping
+        agent.global_step = 42  # Reset to specific value after steps
+        agent.policy_hidden_state = torch.randn(DEPTH, HIDDEN_DIM)
+
+        # Set forward dynamics hidden states
+        for i in range(NUM_LEVELS):
+            agent.forward_dynamics_hiddens[i] = torch.randn(DEPTH, HIDDEN_DIM)
+
+        # Save state
+        save_path = tmp_path / "agent_state"
+        agent.save_state(save_path)
+
+        # Verify files exist
+        assert (save_path / "policy_hidden_state.pt").exists()
+        assert (save_path / "global_step").exists()
+        for i in range(NUM_LEVELS):
+            assert (save_path / f"forward_dynamics_hidden_{i}.pt").exists()
+            assert (save_path / f"surprisal_coefficient_vector_{i}.pt").exists()
+
+        # Create new agent and load state
+        new_agent = HierarchicalCuriosityAgent(num_hierarchical_levels=NUM_LEVELS)
+        new_agent.load_state(save_path)
+
+        # Verify state was loaded correctly
+        assert new_agent.global_step == 42
+        assert new_agent.policy_hidden_state is not None
+        assert torch.allclose(new_agent.policy_hidden_state, agent.policy_hidden_state)
+
+        for i in range(NUM_LEVELS):
+            assert torch.allclose(
+                new_agent.forward_dynamics_hiddens[i],
+                agent.forward_dynamics_hiddens[i],
+            )
+            assert torch.allclose(
+                new_agent.surprisal_coefficient_vectors[i],
+                agent.surprisal_coefficient_vectors[i],
+            )

--- a/tests/exp/trainers/test_forward_dynamics.py
+++ b/tests/exp/trainers/test_forward_dynamics.py
@@ -220,7 +220,6 @@ class TestStackedHiddenFDTrainerExplicitTarget:
             max_epochs=1,
             min_buffer_size=self.LEN,
             min_new_data_count=4,
-            model_index=1,
         )
         return trainer
 

--- a/tests/exp/trainers/test_forward_dynamics.py
+++ b/tests/exp/trainers/test_forward_dynamics.py
@@ -14,7 +14,10 @@ from exp.models import ModelName
 from exp.models.components.qlstm import QLSTM
 from exp.models.forward_dynamics import StackedHiddenFD
 from exp.models.utils import ActionInfo, ObsInfo
-from exp.trainers.forward_dynamics import StackedHiddenFDTrainer
+from exp.trainers.forward_dynamics import (
+    StackedHiddenFDTrainer,
+    StackedHiddenFDTrainerExplicitTarget,
+)
 from tests.helpers import parametrize_device
 
 
@@ -144,4 +147,141 @@ class TestStackedHiddenFDTrainer:
                 seq_len=10,
                 imagination_length=5,
                 min_buffer_size=14,  # Less than seq_len + imagination_length
+            )
+
+
+class TestStackedHiddenFDTrainerExplicitTarget:
+    """Test class for StackedHiddenFDTrainerExplicitTarget."""
+
+    BATCH = 4
+    DEPTH = 8
+    DIM = 16
+    DIM_FF_HIDDEN = 32
+    LEN = 64
+    LEN_SEQ = 16
+    DROPOUT = 0.1
+    DIM_OBS = 32
+    DIM_ACTION = 8
+    ACTION_CHOICES = [4, 9, 2]
+
+    @pytest.fixture
+    def forward_dynamics(self):
+        """Create a StackedHiddenFD model for testing."""
+        obs_info = ObsInfo(dim=self.DIM_OBS, dim_hidden=self.DIM, num_tokens=1)
+        action_info = ActionInfo(choices=self.ACTION_CHOICES, dim=self.DIM_ACTION)
+        core_model = QLSTM(
+            depth=self.DEPTH,
+            dim=self.DIM,
+            dim_ff_hidden=self.DIM_FF_HIDDEN,
+            dropout=self.DROPOUT,
+        )
+        return StackedHiddenFD(
+            obs_info=obs_info,
+            action_info=action_info,
+            dim=self.DIM,
+            core_model=core_model,
+        )
+
+    @pytest.fixture
+    def data_buffers(self):
+        """Create data buffers with TARGET key for explicit target training."""
+        return {
+            BufferName.FORWARD_DYNAMICS: DictSequentialBuffer(
+                [DataKey.OBSERVATION, DataKey.ACTION, DataKey.HIDDEN, DataKey.TARGET],
+                max_size=self.LEN,
+            )
+        }
+
+    @pytest.fixture
+    def trainer(self, mocker: MockerFixture):
+        """Create a StackedHiddenFDTrainerExplicitTarget for testing."""
+        mocker.patch("exp.trainers.forward_dynamics.get_global_run")
+        trainer = StackedHiddenFDTrainerExplicitTarget(
+            partial(AdamW, lr=1e-4, weight_decay=0.04),
+            seq_len=self.LEN_SEQ,
+            max_samples=4,
+            batch_size=2,
+            max_epochs=1,
+            min_buffer_size=self.LEN,
+            min_new_data_count=4,
+        )
+        return trainer
+
+    @pytest.fixture
+    def trainer_with_index(self, mocker: MockerFixture):
+        """Create a trainer with model_index for testing multi-model
+        scenarios."""
+        mocker.patch("exp.trainers.forward_dynamics.get_global_run")
+        trainer = StackedHiddenFDTrainerExplicitTarget(
+            partial(AdamW, lr=1e-4, weight_decay=0.04),
+            seq_len=self.LEN_SEQ,
+            max_samples=4,
+            batch_size=2,
+            max_epochs=1,
+            min_buffer_size=self.LEN,
+            min_new_data_count=4,
+            model_index=1,
+        )
+        return trainer
+
+    def create_action(self) -> torch.Tensor:
+        """Create a random action tensor for testing."""
+        actions = []
+        for choice in self.ACTION_CHOICES:
+            actions.append(torch.randint(0, choice, ()))
+        return torch.stack(actions, dim=-1)
+
+    @parametrize_device
+    def test_run(self, device, data_buffers, forward_dynamics, trainer):
+        """Test the complete training run."""
+        models = {
+            str(ModelName.FORWARD_DYNAMICS): TorchTrainingModel(
+                forward_dynamics, has_inference_model=False, device=device
+            ),
+        }
+        components = connect_components(
+            trainers=trainer, buffers=data_buffers, models=models
+        )
+        collector = components.data_collectors[BufferName.FORWARD_DYNAMICS]
+
+        # Collect training data including explicit targets
+        for _ in range(self.LEN):
+            collector.collect(
+                {
+                    DataKey.OBSERVATION: torch.randn(1, self.DIM_OBS),
+                    DataKey.ACTION: self.create_action(),
+                    DataKey.HIDDEN: torch.randn(self.DEPTH, self.DIM),
+                    DataKey.TARGET: torch.randn(1, self.DIM_OBS),  # Explicit target
+                }
+            )
+
+        assert trainer.global_step == 0
+        assert trainer.run() is True
+        assert trainer.global_step > 0
+        global_step = trainer.global_step
+        assert trainer.run() is False
+        assert trainer.global_step == global_step
+
+    def test_save_and_load_state(self, trainer, tmp_path: Path):
+        """Test saving and loading trainer state."""
+        trainer_path = tmp_path / "trainer"
+        trainer.save_state(trainer_path)
+        global_step = trainer.global_step
+        assert (trainer_path / "global_step").is_file()
+
+        trainer.global_step = -1
+        trainer.load_state(trainer_path)
+        assert trainer.global_step == global_step
+
+    def test_buffer_size_validation(self, mocker: MockerFixture):
+        """Test that buffer size must be greater than seq_len."""
+        mocker.patch("exp.trainers.forward_dynamics.get_global_run")
+        with pytest.raises(
+            ValueError,
+            match="Buffer size must be greater than sequence length",
+        ):
+            StackedHiddenFDTrainerExplicitTarget(
+                partial(AdamW, lr=1e-4, weight_decay=0.04),
+                seq_len=10,
+                min_buffer_size=9,  # Less than seq_len
             )


### PR DESCRIPTION
## Description

先に #40 のレビューをお願いいたいします。

Target を明示的に扱い、またその結果Imagination処理が書けなくなったので、別個のクラスとして実装し直しました。
階層型好奇心のために `model_index`もサポートしています。
<!-- Purpose of changes or related Issue number -->

<!-- If there are UI changes, screenshots for comparison would be helpful -->

## Impact on Other Code/Features

- [ ] None
- [ ] Yes

<!-- If yes, please describe -->

<!-- For example: "Changes to this function affect that feature" etc. -->

## Pre-submit Checklist

<!-- Items to check before submitting PR -->

- [ ] Is the title clear and descriptive, and does the description concisely explain the PR?
- [ ] Have you confirmed your PR handles one specific change rather than bundling different changes together?
- [ ] Have you listed all changes introduced in this PR?
- [ ] Have you tested the PR locally using the `make run` command?

## Additional Notes

<!-- Points to focus on during review, notes for local testing, etc. -->
